### PR TITLE
Hide navigation bar while app loads in the start

### DIFF
--- a/src/app/src/main/java/com/hsousa_apps/Autocarros/MainActivity.kt
+++ b/src/app/src/main/java/com/hsousa_apps/Autocarros/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : AppCompatActivity() {
 
         /** Fetch routes from API **/
         val progressBar: ConstraintLayout = findViewById(R.id.loadingGroup)
+        val bottomNavigation: BottomNavigationView = findViewById(R.id.bottom_navigation)
         val requestQueue: RequestQueue = Volley.newRequestQueue(this)
         val objectRequest: JsonArrayRequest = JsonArrayRequest(
             Request.Method.GET,
@@ -125,7 +126,7 @@ class MainActivity : AppCompatActivity() {
                     }
 
                     progressBar.visibility = View.GONE
-
+                    bottomNavigation.visibility = View.VISIBLE
                     swapFrags(HomeFragment())
                 }catch (e: JSONException){
                     Log.d("ERROR", "JSONException: $e")
@@ -136,7 +137,7 @@ class MainActivity : AppCompatActivity() {
                     }
 
                     progressBar.visibility = View.GONE
-
+                    bottomNavigation.visibility = View.VISIBLE
 
                     val builder = AlertDialog.Builder(this)
                     builder.setTitle(getString(R.string.failed_response_title))
@@ -161,7 +162,7 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 progressBar.visibility = View.GONE
-
+                bottomNavigation.visibility = View.VISIBLE
 
                 val builder = AlertDialog.Builder(this)
                 builder.setTitle(getString(R.string.failed_response_title))

--- a/src/app/src/main/res/layout/main.xml
+++ b/src/app/src/main/res/layout/main.xml
@@ -83,13 +83,14 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="#218732"
+        android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="1.0"
-        app:menu="@menu/bottom_navigation_menu" >
+        app:menu="@menu/bottom_navigation_menu">
 
     </com.google.android.material.bottomnavigation.BottomNavigationView>
 


### PR DESCRIPTION
Wait for the app to load stops and routes from the API before showing bottom navigation bar and let user navigate the app